### PR TITLE
Removed .sh files from gitHub pushes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 *.user
 *.userosscache
 *.sln.docstates
-deploy.sh
+*.sh
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs


### PR DESCRIPTION
This is still the same version because it doesn´t include any major working changes, but It has working examples of usage of the Vertex data structures as well as basic camera movement and text rendering as an overlay on the screen (similar to what was done with the SpaceInvaders project). There´s a lot of changes accumulated here and going forward I intend to link every project recompile to a git push in ordet to atomize git changes and make the process more easily traceable.